### PR TITLE
fix: updated join map compatibile with simpl

### DIFF
--- a/src/JoinMap.cs
+++ b/src/JoinMap.cs
@@ -64,7 +64,7 @@ namespace EpsonProjectorEpi
         public JoinDataComplete MuteOff = new JoinDataComplete(
             new JoinData()
             {
-                JoinNumber = 5,
+                JoinNumber = 21,
                 JoinSpan = 1
             },
             new JoinMetadata()
@@ -78,7 +78,7 @@ namespace EpsonProjectorEpi
         public JoinDataComplete MuteOn = new JoinDataComplete(
             new JoinData()
             {
-                JoinNumber = 6,
+                JoinNumber = 22,
                 JoinSpan = 1
             },
             new JoinMetadata()
@@ -92,7 +92,7 @@ namespace EpsonProjectorEpi
         public JoinDataComplete MuteToggle = new JoinDataComplete(
             new JoinData()
             {
-                JoinNumber = 7,
+                JoinNumber = 23,
                 JoinSpan = 1
             },
             new JoinMetadata()


### PR DESCRIPTION
Join map of plugin changed from what was used on previous versions of the plugin. Updated join map for this instance to use what is expected from simp.

May be better to override the join map or do we want to go with one join map or the other. Refer to v1.0.3 for instance of plugin with join map that matches what was expected in simpl.

This pluign maps video mute on/off/toggle to 5,6,7. v1.0.3 maps to 21.22.23. Simpl code ties control to 21,22,23