### PR TITLE
Add dont unmute video on route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # epi-display-epson_projector
+Crestron Essentials Plugin for Epson Projectors (4-Series)
+
+## Features
+
+- Power control (on/off/toggle)
+- Video input switching (HDMI, DVI, Computer, Video, LAN, HDBaseT)
+- Video mute control
+- Video freeze control
+- Lamp hours monitoring
+- Serial number feedback
+- Communication monitoring
+
+## Configuration
+
+### Properties
+
+- **unmuteVideoOnInputSelection** (bool, default: `true`)
+  - Determines whether video is automatically unmuted when selecting an input
+  - Set to `false` to keep mute status unchanged during input selection
+  - JSON property: `"unmuteVideoOnInputSelection"`
+
+### Example Configuration
+
+```json
+{
+  "key": "roomBBlueDisplay",
+  "name": "1044 Blue Display",
+  "type": "epsonProjector",
+  "group": "display",
+  "properties": {
+    "warmingTimeMs": 14000,
+    "coolingTimeMs": 14000,
+    "unmuteVideoOnInputSelection": false,
+    "control": {
+      "comParams": {
+        "dataBits": 8,
+        "softwareHandshake": "None",
+        "baudRate": 9600,
+        "parity": "None",
+        "stopBits": 1,
+        "hardwareHandshake": "None",
+        "protocol": "RS232"
+      },
+      "method": "com",
+      "controlPortDevKey": "nvxRxBBlueDisplay",
+      "controlPortNumber": 1
+    }
+  }
+}
+```
+
+## Usage
+
+The plugin implements `IRoutingSinkWithSwitchingWithInputPort` for input switching and provides feedbacks for power status, video mute, freeze, and current input.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Crestron Essentials Plugin for Epson Projectors (4-Series)
 
 ### Properties
 
-- **unmuteVideoOnInputSelection** (bool, default: `true`)
-  - Determines whether video is automatically unmuted when selecting an input
-  - Set to `false` to keep mute status unchanged during input selection
-  - JSON property: `"unmuteVideoOnInputSelection"`
+- **dontUnmuteVideoOnRoute** (bool, default: `false`)
+  - When `true`, prevents video from being unmuted during input selection
+  - When `false` (default), video is automatically unmuted when selecting an input (preserves current behavior)
+  - JSON property: `"dontUnmuteVideoOnRoute"`
 
 ### Example Configuration
 
@@ -31,7 +31,7 @@ Crestron Essentials Plugin for Epson Projectors (4-Series)
   "properties": {
     "warmingTimeMs": 14000,
     "coolingTimeMs": 14000,
-    "unmuteVideoOnInputSelection": false,
+    "dontUnmuteVideoOnRoute": true,
     "control": {
       "comParams": {
         "dataBits": 8,

--- a/src/Commands.cs
+++ b/src/Commands.cs
@@ -13,10 +13,13 @@ namespace EpsonProjectorEpi
 
             public void Dispatch()
             {
-                if (Coms == null || String.IsNullOrEmpty(Message))
+                if (Coms == null || string
+
+
+                        .IsNullOrEmpty(Message))
                     return;
 
-                Coms.SendText(Message + "\x0D");
+                Coms.SendText(Message + "\r");
             }
 
             public override string ToString()
@@ -25,11 +28,12 @@ namespace EpsonProjectorEpi
             }
         }
 
-        public const string SourceComputer = "SOURCE 11";
+        public const string SourceComputer = "SOURCE 10";
         public const string SourceHdmi = "SOURCE 30";
         public const string SourceVideo = "SOURCE 45";
+        public const string SourceHdBaseT = "SOURCE 80";
+        public const string SourceLan = "SOURCE 63";
         public const string SourceDvi = "SOURCE A0";
-        public const string SourceLan = "SOURCE 53";
         public const string MuteOn = "MUTE ON";
         public const string MuteOff = "MUTE OFF";
         public const string FreezeOn = "FREEZE ON";

--- a/src/EpsonProjector.cs
+++ b/src/EpsonProjector.cs
@@ -497,6 +497,13 @@ namespace EpsonProjectorEpi
                         Message = Commands.SourceLan,
                     });
                     break;
+                case VideoInputHandler.VideoInputStatusEnum.HdBaseT:
+                    _commandQueue.Enqueue(new Commands.EpsonCommand
+                    {
+                        Coms = _coms,
+                        Message = Commands.SourceHdBaseT,
+                    });
+                    break;
                 case VideoInputHandler.VideoInputStatusEnum.None:
                     break;
                 default:
@@ -531,11 +538,13 @@ namespace EpsonProjectorEpi
                     eRoutingPortConnectionType.Rgb,
                     VideoInputHandler.VideoInputStatusEnum.Video,
                     this) { Port = (int)VideoInputHandler.VideoInputStatusEnum.Video, FeedbackMatchObject = VideoInputHandler.VideoInputStatusEnum.Video },
+
                 new RoutingInputPort("Lan",
                     eRoutingSignalType.Video,
                     eRoutingPortConnectionType.HdBaseT,
                     VideoInputHandler.VideoInputStatusEnum.Lan,
                     this) { Port = (int)VideoInputHandler.VideoInputStatusEnum.Lan, FeedbackMatchObject = VideoInputHandler.VideoInputStatusEnum.Lan },
+
                 new RoutingInputPort("HDBaseT",
                     eRoutingSignalType.Video,
                     eRoutingPortConnectionType.HdBaseT,
@@ -575,13 +584,6 @@ namespace EpsonProjectorEpi
                         { (int)VideoInputHandler.VideoInputStatusEnum.Hdmi, new EpsonInput("Hdmi", "Hdmi", this, SetHDMI) },
                         { (int)VideoInputHandler.VideoInputStatusEnum.Dvi, new EpsonInput("DVI", "DVI-D", this, SetDVI) },
                         { (int)VideoInputHandler.VideoInputStatusEnum.Computer, new EpsonInput("Computer", "Computer", this, SetComputer) },
-                        { (int)VideoInputHandler.VideoInputStatusEnum.Lan,
-                            new EpsonInput("LAN", "LAN", this, () => _commandQueue.Enqueue(new Commands.EpsonCommand
-                            {
-                                Coms = _coms,
-                                Message = Commands.SourceLan,
-                            }))
-                        },
                         { (int)VideoInputHandler.VideoInputStatusEnum.HdBaseT,
                             new EpsonInput("HDBaseT", "HDBaseT", this, () => _commandQueue.Enqueue(new Commands.EpsonCommand
                             {

--- a/src/EpsonProjector.cs
+++ b/src/EpsonProjector.cs
@@ -44,6 +44,11 @@ namespace EpsonProjectorEpi
 
         public ISelectableItems<int> Inputs { get; private set; }
 
+        /// <summary>
+        /// Determines whether video is unmuted when selecting an input
+        /// </summary>
+        public bool UnmuteVideoOnInputSelection { get; set; }
+
         private bool _isWarming;
         private bool _isCooling;
 
@@ -51,6 +56,7 @@ namespace EpsonProjectorEpi
         {
             _coms = coms;
             _config = config;
+            UnmuteVideoOnInputSelection = config.UnmuteVideoOnInputSelection;
             if (config.Monitor == null)
                 config.Monitor = GetDefaultMonitorConfig();
 
@@ -805,6 +811,8 @@ namespace EpsonProjectorEpi
                 _requestedVideoInput = inputToSwitch;
 
                 PowerOn();
+                if (UnmuteVideoOnInputSelection)
+                    VideoMuteOff();
                 VideoFreezeOff();
                 ProcessRequestedVideoInput();
                 _pollTimer.Reset(438, _pollTime);

--- a/src/EpsonProjector.cs
+++ b/src/EpsonProjector.cs
@@ -45,9 +45,9 @@ namespace EpsonProjectorEpi
         public ISelectableItems<int> Inputs { get; private set; }
 
         /// <summary>
-        /// Determines whether video is unmuted when selecting an input
+        /// When true, prevents video from unmuting during input selection
         /// </summary>
-        public bool UnmuteVideoOnInputSelection { get; set; }
+        public bool DontUnmuteVideoOnRoute { get; set; }
 
         private bool _isWarming;
         private bool _isCooling;
@@ -56,7 +56,7 @@ namespace EpsonProjectorEpi
         {
             _coms = coms;
             _config = config;
-            UnmuteVideoOnInputSelection = config.UnmuteVideoOnInputSelection;
+            DontUnmuteVideoOnRoute = config.DontUnmuteVideoOnRoute;
             if (config.Monitor == null)
                 config.Monitor = GetDefaultMonitorConfig();
 
@@ -811,7 +811,7 @@ namespace EpsonProjectorEpi
                 _requestedVideoInput = inputToSwitch;
 
                 PowerOn();
-                if (UnmuteVideoOnInputSelection)
+                if (!DontUnmuteVideoOnRoute)
                     VideoMuteOff();
                 VideoFreezeOff();
                 ProcessRequestedVideoInput();

--- a/src/EpsonProjector.cs
+++ b/src/EpsonProjector.cs
@@ -805,7 +805,6 @@ namespace EpsonProjectorEpi
                 _requestedVideoInput = inputToSwitch;
 
                 PowerOn();
-                VideoMuteOff();
                 VideoFreezeOff();
                 ProcessRequestedVideoInput();
                 _pollTimer.Reset(438, _pollTime);

--- a/src/PropsConfig.cs
+++ b/src/PropsConfig.cs
@@ -23,6 +23,9 @@ namespace EpsonProjectorEpi
         public long WarmupTimeMs { get; set; }
 
         public long CooldownTimeMs { get; set; }
+
+        [JsonProperty("unmuteVideoOnInputSelection")]
+        public bool UnmuteVideoOnInputSelection { get; set; } = true;
     }
     
     public class ActiveInputs

--- a/src/PropsConfig.cs
+++ b/src/PropsConfig.cs
@@ -24,8 +24,8 @@ namespace EpsonProjectorEpi
 
         public long CooldownTimeMs { get; set; }
 
-        [JsonProperty("unmuteVideoOnInputSelection")]
-        public bool UnmuteVideoOnInputSelection { get; set; } = true;
+        [JsonProperty("dontUnmuteVideoOnRoute")]
+        public bool DontUnmuteVideoOnRoute { get; set; } = false;
     }
     
     public class ActiveInputs

--- a/src/VideoInputHandler.cs
+++ b/src/VideoInputHandler.cs
@@ -9,14 +9,14 @@ namespace EpsonProjectorEpi
         public const string SearchString = "SOURCE=";
         public const string VideoInputHdmi = "SOURCE=30";
         public const string VideoInputDvi = "SOURCE=A0";
-        public const string VideoInputComputer = "SOURCE=11";
+        public const string VideoInputComputer = "SOURCE=10";
         public const string VideoInputVideo = "SOURCE=45";
-        
-        public const string VideoInputLan = "SOURCE=50";
+        public const string VideoInputLan = "SOURCE=63";
+        public const string VideoInputHdBaseT = "SOURCE=80";
 
         public enum VideoInputStatusEnum
         {
-            None = 0, Hdmi = 1, Dvi = 2, Computer = 3, Video = 4, Lan = 5
+            None = 0, Hdmi = 1, Dvi = 2, Computer = 3, Video = 4, Lan = 5, HdBaseT = 6
         }
 
         public event EventHandler<Events.VideoInputEventArgs> VideoInputUpdated;
@@ -33,7 +33,7 @@ namespace EpsonProjectorEpi
 
             if (response.Contains(VideoInputHdmi))
             {
-                OnMuteUpdated(new Events.VideoInputEventArgs
+                OnInputUpdated(new Events.VideoInputEventArgs
                     {
                         Input = VideoInputStatusEnum.Hdmi,
                     });
@@ -43,7 +43,7 @@ namespace EpsonProjectorEpi
 
             if (response.Contains(VideoInputDvi))
             {
-                OnMuteUpdated(new Events.VideoInputEventArgs
+                OnInputUpdated(new Events.VideoInputEventArgs
                     {
                         Input = VideoInputStatusEnum.Dvi,
                     });
@@ -53,7 +53,7 @@ namespace EpsonProjectorEpi
 
             if (response.Contains(VideoInputComputer))
             {
-                OnMuteUpdated(new Events.VideoInputEventArgs
+                OnInputUpdated(new Events.VideoInputEventArgs
                     {
                         Input = VideoInputStatusEnum.Computer,
                     });
@@ -63,7 +63,7 @@ namespace EpsonProjectorEpi
 
             if (response.Contains(VideoInputVideo))
             {
-                OnMuteUpdated(new Events.VideoInputEventArgs
+                OnInputUpdated(new Events.VideoInputEventArgs
                     {
                         Input = VideoInputStatusEnum.Video,
                     });
@@ -73,7 +73,7 @@ namespace EpsonProjectorEpi
 
             if (response.Contains(VideoInputLan))
             {
-                OnMuteUpdated(new Events.VideoInputEventArgs
+                OnInputUpdated(new Events.VideoInputEventArgs
                     {
                         Input = VideoInputStatusEnum.Lan,
                     });
@@ -81,10 +81,20 @@ namespace EpsonProjectorEpi
                 return;
             }
 
-            this.LogWarning("Received an unknown video input response: {response}", response);            
+            if (response.Contains(VideoInputHdBaseT))
+            {
+                OnInputUpdated(new Events.VideoInputEventArgs
+                {
+                    Input = VideoInputStatusEnum.HdBaseT,
+                });
+
+                return;
+            }
+
+            this.LogWarning("Received an unknown video input response: {response}", response);
         }
 
-        private void OnMuteUpdated(Events.VideoInputEventArgs args)
+        private void OnInputUpdated(Events.VideoInputEventArgs args)
         {
             var handler = VideoInputUpdated;
             if (handler == null)


### PR DESCRIPTION
This pull request adds support for new video input types (HDBaseT and LAN), introduces a configurable option to control video unmute behavior during input switching, and improves input handling consistency for Epson projector control. The changes update command constants, input processing, and configuration, while also fixing and refactoring input feedback code.

**New Input Support and Input Handling Improvements:**

* Added support for HDBaseT and LAN video input types throughout the codebase, including new command constants (`SourceHdBaseT`, `SourceLan`), enum values, input ports, and input processing logic. [[1]](diffhunk://#diff-d7685f3ceb023d705ae6b9bceefd2b555d4b272603ff74a1796a80ebad9f19b3L28-L32) [[2]](diffhunk://#diff-94243561add98f4332be3393704bdb03f5c40f33af6517c0ccbd99d927d7176eR506-R512) [[3]](diffhunk://#diff-94243561add98f4332be3393704bdb03f5c40f33af6517c0ccbd99d927d7176eR547-R557) [[4]](diffhunk://#diff-94243561add98f4332be3393704bdb03f5c40f33af6517c0ccbd99d927d7176eL570-R599) [[5]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL12-R19) [[6]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL76-R97)
* Updated input feedback handling to use a consistent method (`OnInputUpdated`), replacing previous incorrect references to mute updates, and fixed video input response parsing. [[1]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL36-R36) [[2]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL46-R46) [[3]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL56-R56) [[4]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL66-R66) [[5]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL76-R97)

**Configurable Video Unmute Behavior:**

* Introduced the `dontUnmuteVideoOnRoute` property in `PropsConfig`, allowing configuration to prevent video from being automatically unmuted during input selection; updated usage in `EpsonProjector`. [[1]](diffhunk://#diff-06fdec43ef25df4e6154f3aa407f2c7f106b3bb48e32589c781d70f1af0784d4R26-R28) [[2]](diffhunk://#diff-94243561add98f4332be3393704bdb03f5c40f33af6517c0ccbd99d927d7176eR47-R59) [[3]](diffhunk://#diff-94243561add98f4332be3393704bdb03f5c40f33af6517c0ccbd99d927d7176eR814)
* Documented the new property and its effect in the `README.md`, including example configuration.

**Other Improvements and Fixes:**

* Updated input command constants for accuracy (e.g., `SourceComputer` and `VideoInputComputer` now use "SOURCE 10"). [[1]](diffhunk://#diff-d7685f3ceb023d705ae6b9bceefd2b555d4b272603ff74a1796a80ebad9f19b3L28-L32) [[2]](diffhunk://#diff-ed018f0adf974cd251a88fe89f79ed3c59ea0e02a09b9fbc70d9823a0de28d6aL12-R19)
* Reduced projector polling time for improved responsiveness.
* Minor refactor to clarify carriage return usage in command dispatch.