### PR TITLE
feat!: migrate to Essentials v3 / net8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "chat.tools.terminal.autoApprove": {
-    "/^dotnet (build|restore|clean|test)\\b/": true
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "chat.tools.terminal.autoApprove": {
+    "/^dotnet (build|restore|clean|test)\\b/": true
+  }
+}

--- a/_Context/v3-migration-plan.md
+++ b/_Context/v3-migration-plan.md
@@ -1,0 +1,60 @@
+# v3 Migration Plan — epi-epson-projector
+
+> Generated 2026-08-13 by essentials-epi agent (read-only `scan-plugin-v3-readiness.ps1`, Mode V3). Re-run the scan before starting work in case the repo has drifted since this was written.
+> Work happens on branch `feature/v3-migration`.
+
+## Program Context
+
+This repo is 1 of 5 EPIs being converted to Essentials v3 in this effort:
+`epi-videoCodec-ciscoExtended`, `epi-cisco-cli`, `epi-crestron-nvx`, `epi-epson-projector`, `epi-netgear-cli`.
+**This one is the pilot** — smallest/lowest-risk, done first to validate the pattern before the others.
+`epi-videoCodec-ciscoExtended` is on hold until its in-progress feature branches are merged to `main`.
+
+## Current State
+
+| | |
+|---|---|
+| Target framework | `net472` |
+| Essentials version | `2.4.7` |
+| `SERIES4` define | present (both Debug/Release `PropertyGroup`s) |
+| C# files | 18 |
+| `#if SERIES4` conditionals | 0 |
+| Removed .NET APIs | 0 |
+| Factory | 1 — `src\DeviceFactory.cs`, class `DeviceFactory`, `MinimumEssentialsFrameworkVersion = "2.4.7"` |
+| 3-Series artifacts | `packages.config` |
+| Debug.Console remaining | 0 (already 12 calls migrated to Serilog) |
+
+## Risk: **Low**
+
+No conditionals, no removed APIs, single factory, small file count, logging already mostly migrated.
+
+## Skill to Use
+
+[`sub-agents/essentials-epi/skills/migrate-v2-to-v3/SKILL.md`](../../../skills/migrate-v2-to-v3/SKILL.md) — standard 5-phase workflow. No routing migration needed (no `IRouting`/`IMatrixRouting` usage detected).
+
+## Pre-Flight (do first, every session — per essentials-epi's mandatory git pre-flight rule)
+
+1. `git fetch`, confirm branch is `feature/v3-migration`, confirm 0 behind upstream, confirm clean working tree.
+2. Confirm this branch is still correctly based on an up-to-date `main`.
+
+## Task Checklist
+
+- [ ] Re-run `analyze-plugin` scan to confirm nothing changed since this plan was written
+- [ ] Phase 2a: `<TargetFramework>net472</TargetFramework>` → `net8` in `src\epi-epson-projector.4Series.csproj`
+- [ ] Phase 2a: remove both `SERIES4` `DefineConstants` `PropertyGroup` blocks
+- [ ] Phase 2a: bump `PepperDashEssentials` PackageReference to `3.0.0`
+- [ ] Phase 2b: `MinimumEssentialsFrameworkVersion = "2.4.7"` → `"3.0.0"` in `DeviceFactory.cs`
+- [ ] Phase 2c: delete `packages.config`
+- [ ] Phase 2c: check for a stray 3-Series `.csproj`/`.sln` (none detected in this scan, but re-verify)
+- [ ] Phase 3a: no `#if SERIES4` conditionals to remove (verify still true)
+- [ ] Phase 3b: no `Debug.Console` calls to migrate (verify still true — grep to confirm 0 remaining)
+- [ ] Phase 3c: check `Initialize()`/`CustomActivate()` visibility (`public` → `protected override`) and any external callers
+- [ ] Phase 4: verify join map — all fields `public`, `base(joinStart, typeof(...))`, `[JoinName]` attributes match
+- [ ] Phase 5: `dotnet restore` + `dotnet build` on `epi-epson-projector.4Series.sln`, fix any compile errors
+- [ ] Update README's "Minimum Essentials Framework Versions" section if present
+- [ ] Commit with `feat!:` / `BREAKING CHANGE:` footer (major version bump)
+- [ ] Verify `output/` `.cplz` builds
+
+## Notes / Flags
+
+- None outstanding — cleanest of the 5 repos.

--- a/epi-epson-projector.4Series.sln
+++ b/epi-epson-projector.4Series.sln
@@ -5,19 +5,52 @@ VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "epi-epson-projector.4Series", "src\epi-epson-projector.4Series.csproj", "{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "epi-epson-projector.Tests", "tests\epi-epson-projector.Tests.csproj", "{D65F857A-3FE1-4142-B66C-B33AD209E764}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x64.Build.0 = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Debug|x86.Build.0 = Debug|Any CPU
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x64.ActiveCfg = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x64.Build.0 = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x86.ActiveCfg = Release|Any CPU
+		{52E6E0A0-A710-4B5F-AF52-08816F5C99BB}.Release|x86.Build.0 = Release|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Debug|x64.Build.0 = Debug|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Debug|x86.Build.0 = Debug|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Release|x64.ActiveCfg = Release|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Release|x64.Build.0 = Release|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Release|x86.ActiveCfg = Release|Any CPU
+		{D65F857A-3FE1-4142-B66C-B33AD209E764}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D65F857A-3FE1-4142-B66C-B33AD209E764} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {45BE70E2-A4DC-4851-92ED-CE67B99F5D86}

--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,0 @@
-<packages>
-  <package id="PepperDashEssentials" version="2.4.7" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
-</packages>

--- a/src/Commands.cs
+++ b/src/Commands.cs
@@ -2,7 +2,7 @@
 using PepperDash.Core;
 using PepperDash.Essentials.Core.Queues;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public static class Commands
     {

--- a/src/DeviceFactory.cs
+++ b/src/DeviceFactory.cs
@@ -2,13 +2,13 @@
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class DeviceFactory : EssentialsPluginDeviceFactory<EpsonProjector>
     {
         public DeviceFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.7";
+            MinimumEssentialsFrameworkVersion = "3.0.0-dev-v3-routing.62";
             TypeNames = new List<string>() { "epsonProjector" };
         }
 

--- a/src/ELensFunction.cs
+++ b/src/ELensFunction.cs
@@ -1,4 +1,4 @@
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
   public enum ELensFunction
     {

--- a/src/ERemoteControls.cs
+++ b/src/ERemoteControls.cs
@@ -1,4 +1,4 @@
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
   public enum ERemoteControls
     {

--- a/src/EpsonInputs.cs
+++ b/src/EpsonInputs.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class EpsonInputs : ISelectableItems<int>
     {

--- a/src/EpsonProjector.cs
+++ b/src/EpsonProjector.cs
@@ -6,7 +6,7 @@ using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Queues;
 using Feedback = PepperDash.Essentials.Core.Feedback;
-using Thread = Crestron.SimplSharpPro.CrestronThread.Thread;
+using System.Threading;
 using PepperDash.Essentials.Core.DeviceTypeInterfaces;
 using System.Collections.Generic;
 using PepperDash.Essentials.Devices.Common.Displays;
@@ -14,10 +14,10 @@ using PepperDash.Essentials.Core.Bridges;
 using PepperDash.Core.Logging;
 
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class EpsonProjector : TwoWayDisplayBase, IHasPowerControlWithFeedback,
-        IWarmingCooling, IOnline, IBasicVideoMuteWithFeedback, ICommunicationMonitor, IHasInputs<int>, IBridgeAdvanced, IRoutingSinkWithSwitchingWithInputPort
+        IWarmingCooling, IOnline, IBasicVideoMuteWithFeedback, ICommunicationMonitor, IHasInputs<int>, IBridgeAdvanced
     {
         private readonly IBasicCommunication _coms;
         private readonly PropsConfig _config;
@@ -63,7 +63,7 @@ namespace EpsonProjectorEpi
             CommunicationMonitor = new GenericCommunicationMonitor(this, coms, config.Monitor);
             var gather = new CommunicationGather(coms, "\x0D:");
 
-            _commandQueue = new GenericQueue(key + "-command-queue", 213, Thread.eThreadPriority.MediumPriority, 50);
+            _commandQueue = new GenericQueue(key + "-command-queue", 213, ThreadPriority.Normal, 50);
 
             SetupInputs();
 
@@ -192,7 +192,7 @@ namespace EpsonProjectorEpi
             VideoMuteIsOff.FireUpdate();
         }
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             Feedbacks.RegisterForConsoleUpdates(this);
             Feedbacks.FireAllFeedbacks();

--- a/src/Events.cs
+++ b/src/Events.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public static class Events
     {

--- a/src/FeedbackExt.cs
+++ b/src/FeedbackExt.cs
@@ -3,7 +3,7 @@ using PepperDash.Core;
 using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public static class FeedbackExt
     {

--- a/src/JoinMap.cs
+++ b/src/JoinMap.cs
@@ -1,6 +1,6 @@
 ﻿using PepperDash.Essentials.Core;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class JoinMap : JoinMapBaseAdvanced
     {

--- a/src/LampHoursHandler.cs
+++ b/src/LampHoursHandler.cs
@@ -4,7 +4,7 @@ using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Queues;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class LampHoursHandler : IKeyed
     {

--- a/src/PowerHandler.cs
+++ b/src/PowerHandler.cs
@@ -2,7 +2,7 @@
 using PepperDash.Core;
 using PepperDash.Core.Logging;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class PowerHandler : IKeyed
     {

--- a/src/PropsConfig.cs
+++ b/src/PropsConfig.cs
@@ -4,7 +4,7 @@ using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
 using PepperDash.Core;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class PropsConfig
     {

--- a/src/SerialNumberHandler.cs
+++ b/src/SerialNumberHandler.cs
@@ -4,7 +4,7 @@ using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Queues;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class SerialNumberHandler : IKeyed
     {

--- a/src/VideoFreezeHandler.cs
+++ b/src/VideoFreezeHandler.cs
@@ -2,7 +2,7 @@
 using PepperDash.Core;
 using PepperDash.Core.Logging;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class VideoFreezeHandler : IKeyed
     {

--- a/src/VideoInputHandler.cs
+++ b/src/VideoInputHandler.cs
@@ -2,7 +2,7 @@
 using PepperDash.Core;
 using PepperDash.Core.Logging;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class VideoInputHandler : IKeyed
     {

--- a/src/VideoMuteHandler.cs
+++ b/src/VideoMuteHandler.cs
@@ -2,7 +2,7 @@
 using PepperDash.Core;
 using PepperDash.Core.Logging;
 
-namespace EpsonProjectorEpi
+namespace PepperDash.Essentials.Plugins
 {
     public class VideoMuteHandler : IKeyed
     {

--- a/src/epi-epson-projector.4Series.csproj
+++ b/src/epi-epson-projector.4Series.csproj
@@ -3,10 +3,11 @@
 		<ProjectType>ProgramLibrary</ProjectType>
 	</PropertyGroup>
 	<PropertyGroup>
-		<TargetFramework>net472</TargetFramework>
-		<RootNamespace>EPI.Epson.Projector</RootNamespace>
+		<TargetFramework>net8</TargetFramework>
+		<RootNamespace>PepperDash.Essentials.Plugins</RootNamespace>
+		<AssemblyName>PepperDash.Essentials.Plugins.Epson.Projector</AssemblyName>
 		<Deterministic>false</Deterministic>
-		<AssemblyTitle>PepperDash.Essentials.Plugin.Epson.Projector</AssemblyTitle>
+		<AssemblyTitle>PepperDash.Essentials.Plugins.Epson.Projector</AssemblyTitle>
 		<Company>PepperDash Technologies</Company>
 		<Description>PepperDash Essentials Plugin for Epson Projector</Description>
 		<Copyright>Copyright 2025</Copyright>
@@ -15,13 +16,9 @@
 		<InformationalVersion>$(Version)</InformationalVersion>
 		<OutputPath>bin\$(Configuration)\</OutputPath>
 		<Authors>PepperDash Technologies</Authors>
-		<PackageId>Pepperdash.Essentials.Plugin.EpsonProjector</PackageId>
+		<PackageId>PepperDash.Essentials.Plugins.Epson.Projector</PackageId>
 		<PackageProjectUrl>https://github.com/PepperDash/epi-epson-projector.git</PackageProjectUrl>
 		<PackageTags>crestron 4series essentials plugin epson projector</PackageTags>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -43,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="2.4.7" >
+    <PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-routing.62" >
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace EpsonProjector.Tests;
+
+public static class AssemblyFixture
+{
+    private static readonly Lazy<MetadataLoadContext> LazyContext = new(CreateContext);
+    private static readonly Lazy<Assembly> LazyAssembly = new(LoadPluginAssembly);
+
+    private static string Configuration
+    {
+        get
+        {
+            // Derive from test output path: tests/bin/{Configuration}/net8.0/
+            var baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+            var parts = baseDir.Split(Path.DirectorySeparatorChar);
+            return parts[^2]; // net8.0 is last, Configuration is second-to-last
+        }
+    }
+
+    // Flat src/ layout (no src/4Series/ subdir) -> src/bin/{Config}/net8/
+    private static string PluginDllPath =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..",
+            "src", "bin", Configuration, "net8",
+            "PepperDash.Essentials.Plugins.Epson.Projector.dll"));
+
+    private static string PluginOutputDir => Path.GetDirectoryName(PluginDllPath)!;
+
+    public static MetadataLoadContext Context => LazyContext.Value;
+    public static Assembly PluginAssembly => LazyAssembly.Value;
+
+    private static MetadataLoadContext CreateContext()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var dllByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // Fail clearly if the plugin hasn't been built yet, rather than letting
+        // Directory.GetFiles throw a less actionable DirectoryNotFoundException below.
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
+
+        // Priority 1: Plugin output dir (correct versions win)
+        foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
+            dllByName[Path.GetFileName(dll)] = dll;
+
+        // Priority 2: .NET runtime
+        foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
+            dllByName.TryAdd(Path.GetFileName(dll), dll);
+
+        // Priority 3: project.assets.json resolution for transitive packages.
+        // NOT deps.json - the csproj uses <ExcludeAssets>runtime</ExcludeAssets> on the
+        // PepperDashEssentials reference (Essentials itself provides these DLLs on the
+        // processor at runtime), so the plugin's own deps.json omits every dependency
+        // entirely. project.assets.json has the full pre-exclusion dependency graph.
+        var assetsJsonPath = Path.Combine(SourceDirectory, "obj", "project.assets.json");
+        if (File.Exists(assetsJsonPath))
+        {
+            foreach (var path in ResolveProjectAssetsAssemblies(assetsJsonPath))
+                dllByName.TryAdd(Path.GetFileName(path), path);
+        }
+
+        return new MetadataLoadContext(new PathAssemblyResolver(dllByName.Values));
+    }
+
+    private static IEnumerable<string> ResolveProjectAssetsAssemblies(string assetsJsonPath)
+    {
+        // Honor NUGET_PACKAGES (common in CI / enterprise setups); fall back to the default.
+        var nugetDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrWhiteSpace(nugetDir))
+            nugetDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget", "packages");
+
+        using var stream = File.OpenRead(assetsJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+
+        if (!doc.RootElement.TryGetProperty("targets", out var targets))
+            yield break;
+
+        // There's exactly one target framework moniker per build; take whichever is present
+        // rather than hard-coding "net8.0" (some restores key it slightly differently).
+        var target = targets.EnumerateObject().FirstOrDefault();
+        if (target.Value.ValueKind != JsonValueKind.Object)
+            yield break;
+
+        foreach (var lib in target.Value.EnumerateObject())
+        {
+            // Library key is "PackageId/Version"
+            var slash = lib.Name.LastIndexOf('/');
+            if (slash < 0) continue;
+            var packageId = lib.Name[..slash].ToLowerInvariant();
+            var version = lib.Name[(slash + 1)..];
+
+            if (!lib.Value.TryGetProperty("compile", out var assets) &&
+                !lib.Value.TryGetProperty("runtime", out assets))
+                continue;
+
+            foreach (var asset in assets.EnumerateObject())
+            {
+                // "_._" is NuGet's placeholder for "no asset of this kind" - skip it.
+                if (!asset.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var dllPath = Path.Combine(nugetDir, packageId, version,
+                    asset.Name.Replace('/', Path.DirectorySeparatorChar));
+                if (File.Exists(dllPath))
+                    yield return dllPath;
+            }
+        }
+    }
+
+    private static Assembly LoadPluginAssembly()
+    {
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
+        return Context.LoadFromAssemblyPath(PluginDllPath);
+    }
+
+    // Walks the FULL base-type chain — handles factories that derive through an intermediate
+    // base, not just direct subclasses.
+    public static List<Type> FindFactoryTypes(string baseTypePrefix = "EssentialsPluginDeviceFactory")
+    {
+        return PluginAssembly.GetTypes()
+            .Where(t => !t.IsAbstract && InheritsFromFactory(t, baseTypePrefix))
+            .ToList();
+    }
+
+    private static bool InheritsFromFactory(Type type, string prefix)
+    {
+        for (var b = type.BaseType; b != null; b = b.BaseType)
+            if (b.IsGenericType && b.GetGenericTypeDefinition().Name.StartsWith(prefix))
+                return true;
+        return false;
+    }
+
+    public static string SourceDirectory =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+
+    // Read every source file once, then search in memory.
+    private static readonly Lazy<string[]> AllSourceContents = new(() =>
+        Directory.GetFiles(SourceDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .Select(File.ReadAllText)
+            .ToArray());
+
+    public static string? FindSourceForClass(string className) =>
+        AllSourceContents.Value.FirstOrDefault(content => DeclaresClass(content, className));
+
+    private static bool DeclaresClass(string content, string className)
+    {
+        var needle = "class " + className;
+        for (var i = content.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = content.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            var after = i + needle.Length;
+            var next = after < content.Length ? content[after] : ' ';
+            if (!char.IsLetterOrDigit(next) && next != '_')
+                return true;
+        }
+        return false;
+    }
+}

--- a/tests/ConfigDeserializationTests.cs
+++ b/tests/ConfigDeserializationTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Xunit;
+
+namespace EpsonProjector.Tests;
+
+public class ConfigDeserializationTests
+{
+    [Fact]
+    public void PropsConfig_Class_Exists()
+    {
+        AssemblyFixture.PluginAssembly.GetType("PepperDash.Essentials.Plugins.PropsConfig")
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PropsConfig_Has_Parameterless_Constructor()
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType("PepperDash.Essentials.Plugins.PropsConfig");
+        type!.GetConstructor(Type.EmptyTypes).Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("Control")]
+    [InlineData("Monitor")]
+    [InlineData("EnableBridgeComms")]
+    [InlineData("WarmupTimeMs")]
+    [InlineData("CooldownTimeMs")]
+    [InlineData("ActiveInputs")]
+    [InlineData("DontUnmuteVideoOnRoute")]
+    public void PropsConfig_Has_Expected_Property(string propertyName)
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType("PepperDash.Essentials.Plugins.PropsConfig");
+        type!.GetProperty(propertyName).Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("ActiveInputs", "activeInputs")]
+    [InlineData("DontUnmuteVideoOnRoute", "dontUnmuteVideoOnRoute")]
+    public void PropsConfig_Property_Has_JsonPropertyAttribute(string propertyName, string jsonName)
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType("PepperDash.Essentials.Plugins.PropsConfig");
+        var property = type!.GetProperty(propertyName);
+
+        var hasAttribute = property!.CustomAttributes.Any(a =>
+            a.AttributeType.Name == "JsonPropertyAttribute"
+            && a.ConstructorArguments.Any(arg =>
+                string.Equals(arg.Value?.ToString(), jsonName, StringComparison.Ordinal)));
+
+        hasAttribute.Should().BeTrue($"{propertyName} should be decorated with [JsonProperty(\"{jsonName}\")]");
+    }
+
+    [Fact]
+    public void ActiveInputs_Class_Exists()
+    {
+        AssemblyFixture.PluginAssembly.GetType("PepperDash.Essentials.Plugins.ActiveInputs")
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ActiveInputs_Has_Parameterless_Constructor()
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType("PepperDash.Essentials.Plugins.ActiveInputs");
+        type!.GetConstructor(Type.EmptyTypes).Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("Key", "key")]
+    [InlineData("Name", "name")]
+    public void ActiveInputs_Property_Has_JsonPropertyAttribute(string propertyName, string jsonName)
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType("PepperDash.Essentials.Plugins.ActiveInputs");
+        var property = type!.GetProperty(propertyName);
+
+        var hasAttribute = property!.CustomAttributes.Any(a =>
+            a.AttributeType.Name == "JsonPropertyAttribute"
+            && a.ConstructorArguments.Any(arg =>
+                string.Equals(arg.Value?.ToString(), jsonName, StringComparison.Ordinal)));
+
+        hasAttribute.Should().BeTrue($"{propertyName} should be decorated with [JsonProperty(\"{jsonName}\")]");
+    }
+}

--- a/tests/FactoryDiscoveryTests.cs
+++ b/tests/FactoryDiscoveryTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Xunit;
+
+namespace EpsonProjector.Tests;
+
+public class FactoryDiscoveryTests
+{
+    [Fact]
+    public void Assembly_Loads_Successfully()
+    {
+        AssemblyFixture.PluginAssembly.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Assembly_Name_Matches_Expected()
+    {
+        AssemblyFixture.PluginAssembly.GetName().Name
+            .Should().Be("PepperDash.Essentials.Plugins.Epson.Projector");
+    }
+
+    [Fact]
+    public void Factory_Count_Matches_Expected()
+    {
+        AssemblyFixture.FindFactoryTypes().Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData("DeviceFactory")]
+    public void Factory_Exists_ByName(string factoryClassName)
+    {
+        var factories = AssemblyFixture.FindFactoryTypes();
+        factories.Should().Contain(t => t.Name == factoryClassName);
+    }
+
+    [Fact]
+    public void All_Factories_Have_Parameterless_Constructor()
+    {
+        foreach (var factory in AssemblyFixture.FindFactoryTypes())
+        {
+            factory.GetConstructor(Type.EmptyTypes)
+                .Should().NotBeNull($"factory {factory.Name} must have a parameterless constructor for plugin discovery");
+        }
+    }
+}

--- a/tests/FactoryMetadataTests.cs
+++ b/tests/FactoryMetadataTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Xunit;
+
+namespace EpsonProjector.Tests;
+
+// MinimumEssentialsFrameworkVersion and TypeNames are assigned at runtime in the factory
+// constructor, which MetadataLoadContext cannot execute — source scanning is the only way
+// to verify these without spinning up the Essentials runtime.
+public class FactoryMetadataTests
+{
+    private const string ExpectedMinimumEssentialsFrameworkVersion = "3.0.0-dev-v3-routing.62";
+
+    [Fact]
+    public void Factory_Source_Sets_MinimumEssentialsFrameworkVersion()
+    {
+        var source = AssemblyFixture.FindSourceForClass("DeviceFactory");
+        source.Should().NotBeNull();
+        source!.Should().Contain($"MinimumEssentialsFrameworkVersion = \"{ExpectedMinimumEssentialsFrameworkVersion}\"");
+    }
+
+    [Fact]
+    public void Factory_Source_Sets_TypeNames()
+    {
+        var source = AssemblyFixture.FindSourceForClass("DeviceFactory");
+        source.Should().NotBeNull();
+        source!.Should().Contain("TypeNames = new List<string>()");
+    }
+
+    [Theory]
+    [InlineData("DeviceFactory", "epsonProjector")]
+    public void Factory_Source_Contains_TypeName(string factoryClassName, string typeName)
+    {
+        var source = AssemblyFixture.FindSourceForClass(factoryClassName);
+        source.Should().NotBeNull();
+        source!.Should().Contain($"\"{typeName}\"");
+    }
+}

--- a/tests/epi-epson-projector.Tests.csproj
+++ b/tests/epi-epson-projector.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Ensures the plugin is built before tests run (no direct assembly reference) -->
+    <ProjectReference Include="..\src\epi-epson-projector.4Series.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Migrates epi-epson-projector from v2 (net472, SERIES4, PepperDashEssentials 2.x) to v3 (net8, PepperDashEssentials 3.0.0-dev-v3-routing.62).

## Changes
- Target net8, remove SERIES4 conditional PropertyGroup
- Bump PepperDashEssentials to 3.0.0-dev-v3-routing.62 (factory + csproj)
- Fix AssemblyName/PackageId/namespace to PepperDash.Essentials.Plugins(.Epson.Projector) per naming convention (was non-compliant)
- Remove packages.config (3-Series artifact)
- CustomActivate() visibility: public -> protected override
- Remove stale IRoutingSinkWithSwitchingWithInputPort interface (consolidated into IRoutingSinkWithFeedback, already satisfied via TwoWayDisplayBase/DisplayBase)
- Fix GenericQueue constructor call for System.Threading.ThreadPriority
- Add xUnit validation test suite (factory discovery, factory metadata, config deserialization) - 23 tests passing

## Notes
- Targets a prerelease Essentials version (3.0.0-dev-v3-routing.62) - marked draft pending that line stabilizing / hardware validation.
- BREAKING CHANGE: requires Essentials v3 and a 4-Series processor.